### PR TITLE
ci: add action to sync data plan

### DIFF
--- a/.github/workflows/sync-higgs-shop-data-plan.yml
+++ b/.github/workflows/sync-higgs-shop-data-plan.yml
@@ -1,0 +1,65 @@
+name: Sync Higgs Shop Data Plan
+
+on: [workflow_dispatch]
+
+jobs:
+    fetch-data-plan:
+        name: Fetch Data Plan
+        uses: mParticle/mparticle-workflows/.github/workflows/data-plan-fetch.yml@stable
+        with:
+            data_plan_id: higgs_shop_basic_data_plan
+            data_plan_version: 1
+            app_relative_path: core-sdk-samples/higgs-shop-sample-app
+        secrets:
+            WORKSPACE_ID: ${{ secrets.HIGGS_SHOP_WORKSPACE_ID }}
+            CLIENT_ID: ${{ secrets.HIGGS_SHOP_CLIENT_ID }}
+            CLIENT_SECRET: ${{ secrets.HIGGS_SHOP_CLIENT_SECRET }}
+
+    open-pull-request:
+        name: Open Pull Request for Data Plan
+        runs-on: ubuntu-latest
+        needs: fetch-data-plan
+        env:
+            GIT_AUTHOR_NAME: mparticle-automation
+            GIT_AUTHOR_EMAIL: developers@mparticle.com
+            GIT_COMMITTER_NAME: mparticle-automation
+            GIT_COMMITTER_EMAIL: developers@mparticle.com
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  ref: development
+
+            - name: Download Data Plan Artifacts
+              uses: actions/download-artifact@v3
+              with:
+                  name: higgs-shop-dataplan
+                  path: core-sdk-samples/higgs-shop-sample-app/dataplans
+
+            - name: 'Import GPG Key'
+              uses: crazy-max/ghaction-import-gpg@v4
+              with:
+                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.GPG_PASSPHRASE }}
+                  git_user_signingkey: true
+                  git_commit_gpgsign: true
+
+            - name: Create Commit if Data Plan Changed
+              uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                  commit_message: 'chore: update Higgs Shop Data Plan'
+                  branch: chore/data-plan-update-${{ github.run_number }}
+                  create_branch: true
+                  commit_user_name: mparticle-automation
+                  commit_user_email: developers@mparticle.com
+                  commit_author: mparticle-automation <developers@mparticle.com>
+                  file_pattern: core-sdk-samples/higgs-shop-sample-app/dataplans/*
+
+            - name: Open Pull Request
+              uses: vsoch/pull-request-action@1.0.19
+              env:
+                  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+                  PULL_REQUEST_BRANCH: development
+                  PULL_REQUEST_FROM_BRANCH: chore/data-plan-update-${{ github.run_number }}
+                  PULL_REQUEST_TITLE: 'chore: update Higgs Shop Data Plan'
+                  PULL_REQUEST_DRAFT: 'Updating Higgs Shop Data Plan'


### PR DESCRIPTION
# Summary

- Adding an action that will fetch the current data plan and commit it to the repo within a dataplans folder within the Higgs Shop Sample app.
- This will run during the Build and Release process for now, but I would anticipate moving this to every PR build when we are able to integrate the linter or validation.
- Repeats work done on Web Sample App: https://github.com/mParticle/mparticle-web-sample-apps/pull/85

# Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3684